### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "bootstrap": "latest",
     "hammerjs": "^2.0.8",
     "jquery": "latest",
-    "npm": "latest",
     "popper.js": "latest"
   }
 }


### PR DESCRIPTION

Hello rumatarin!

It seems like you have npm as one of your (dev-) dependency in suntours.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
